### PR TITLE
Fix list concatenation error in Django 1.6

### DIFF
--- a/requirejs/filter.py
+++ b/requirejs/filter.py
@@ -80,7 +80,7 @@ class RequireJSCompiler(FilterBase):
 
         Returns the rewritten content of the module and None if no define-call was found.
         """
-        text_content = text_type(original_content)
+        text_content = text_type(original_content, settings.FILE_CHARSET)
         define_call = define_replace_pattern.findall(text_content)
         if define_call:
             if not module.named:
@@ -121,7 +121,7 @@ class RequireJSCompiler(FilterBase):
         """
         # Compress it
         compressor = JsCompressor()
-        filtered = compressor.filter(content, method='input', kind='js')
+        filtered = compressor.filter(content, compressor.cached_filters, method='input', kind='js')
         output = compressor.filter_output(filtered)
         path = compressor.get_filepath(output, basename=basename)
         # Write it

--- a/requirejs/utils.py
+++ b/requirejs/utils.py
@@ -11,7 +11,7 @@ def get_app_template_dirs():
         from django.template.utils import get_app_template_dirs
 
         app_template_dirs = get_app_template_dirs('templates')
-    return app_template_dirs
+    return list(app_template_dirs)
 
 
 def is_app_installed(label):


### PR DESCRIPTION
`app_template_dirs` returns a Tuple which cannot be concatenated with
List.
